### PR TITLE
Return errors for a group’s dependant predicates if any have failed

### DIFF
--- a/lib/dry/validation/schema.rb
+++ b/lib/dry/validation/schema.rb
@@ -72,8 +72,9 @@ module Dry
 
         groups.each do |group|
           values = group.rules.map { |name|
-            successes.detect { |result| result.name == name }.input
-          }
+            success = successes.detect { |result| result.name == name }
+            success && success.input
+          }.compact
 
           next if values.empty?
 

--- a/spec/integration/rule_groups_spec.rb
+++ b/spec/integration/rule_groups_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe Dry::Validation::Schema do
           ]
         ])
       end
+
+      it 'returns errors for the dependent predicates, not the group rule, when any of the dependent predicates fail' do
+        expect(validation.(password: '', password_confirmation: '')).to match_array([
+          [:error, [:input, [:password, "", [[:val, [:password, [:predicate, [:filled?, []]]]]]]]],
+          [:error, [:input, [:password_confirmation, "", [[:val, [:password_confirmation, [:predicate, [:filled?, []]]]]]]]]
+        ])
+      end
     end
   end
 end


### PR DESCRIPTION
Without this change, a schema with group rule would crash if any of those group’s dependant predicates failed (e.g. if you had a schema with `confirmation(:password)` that you called with either the `password` or `password_confirmation` keys missing or with empty values).

Previously, with a simple schema like this, using the new `confirmation` shortcut:

```ruby
schema = Class.new(Dry::Validation::Schema) {
  confirmation(:password)
}.new
```

Calling with missing input values will result in a crash:

```
> schema.call({})

NoMethodError: undefined method `input' for nil:NilClass
from /Users/tim/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/dry-validation-cb895f62ba6c/lib/dry/validation/schema.rb:75:in `block (2 levels) in call'
```

The same thing happens if at least one of the input values is empty:

```
> schema.call(password: "hi", password_confirmation: "")
NoMethodError: undefined method `input' for nil:NilClass
from /Users/tim/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/dry-validation-cb895f62ba6c/lib/dry/validation/schema.rb:75:in `block (2 levels) in call'
```

Now, it won't crash, and it'll actually return the error messages for the failed dependant predicates:

```
> schema.call(password: "hi", password_confirmation: "")
=> #<Dry::Validation::Schema::Result params={:password=>"hi", :password_confirmation=>""} errors=#<Dry::Validation::Error::Set:0x007fcab1288538 @errors=[#<Dry::Validation::Error:0x007fcab12884c0 @result=#<Dry::Validation::Result::Value success?=false input="" rule=#<Dry::Validation::Rule::Value name=:password_confirmation predicate=#<Dry::Validation::Predicate id=:filled?>>>>]>>

> schema.messages(password: "hi", password_confirmation: "")
=> #<Dry::Validation::Schema::Result params={:password=>"hi", :password_confirmation=>""} errors=[[:password_confirmation, ["password_confirmation must be filled"]]]>
```