### PR TITLE
Refactor schema/validation result objects

### DIFF
--- a/lib/dry/validation/error.rb
+++ b/lib/dry/validation/error.rb
@@ -6,8 +6,8 @@ module Dry
 
         attr_reader :errors
 
-        def initialize
-          @errors = []
+        def initialize(errors)
+          @errors = errors
         end
 
         def each(&block)
@@ -16,10 +16,6 @@ module Dry
 
         def empty?
           errors.empty?
-        end
-
-        def <<(error)
-          errors << error
         end
 
         def to_ary

--- a/lib/dry/validation/result.rb
+++ b/lib/dry/validation/result.rb
@@ -1,0 +1,33 @@
+module Dry
+  module Validation
+    class Result
+      include Enumerable
+
+      attr_reader :rule_results
+
+      def initialize(rule_results)
+        @rule_results = rule_results
+      end
+
+      def each(&block)
+        rule_results.each(&block)
+      end
+
+      def to_ary
+        failures.map(&:to_ary)
+      end
+
+      def <<(rule_result)
+        rule_results << rule_result
+      end
+
+      def successes
+        rule_results.select(&:success?)
+      end
+
+      def failures
+        rule_results.select(&:failure?)
+      end
+    end
+  end
+end

--- a/lib/dry/validation/result.rb
+++ b/lib/dry/validation/result.rb
@@ -21,6 +21,15 @@ module Dry
         rule_results << rule_result
       end
 
+      def with_values(names, &block)
+        values = names.map { |name| by_name(name) }.compact.map(&:input)
+        yield(values) if values.size == names.size
+      end
+
+      def by_name(name)
+        successes.detect { |rule_result| rule_result.name == name }
+      end
+
       def successes
         rule_results.select(&:success?)
       end

--- a/lib/dry/validation/rule.rb
+++ b/lib/dry/validation/rule.rb
@@ -1,5 +1,3 @@
-require 'dry/validation/result'
-
 module Dry
   module Validation
     class Rule
@@ -45,3 +43,4 @@ require 'dry/validation/rule/each'
 require 'dry/validation/rule/set'
 require 'dry/validation/rule/composite'
 require 'dry/validation/rule/group'
+require 'dry/validation/rule/result'

--- a/lib/dry/validation/rule/result.rb
+++ b/lib/dry/validation/rule/result.rb
@@ -2,17 +2,17 @@ module Dry
   module Validation
     def self.Result(input, value, rule)
       case value
-      when Array then Result::Set.new(input, value, rule)
-      else Result::Value.new(input, value, rule)
+      when Array then Rule::Result::Set.new(input, value, rule)
+      else Rule::Result::Value.new(input, value, rule)
       end
     end
 
-    class Result
+    class Rule::Result
       include Dry::Equalizer(:success?, :input, :rule)
 
       attr_reader :input, :value, :rule, :name
 
-      class Set < Result
+      class Rule::Result::Set < Rule::Result
         def success?
           value.all?(&:success?)
         end
@@ -23,7 +23,7 @@ module Dry
         end
       end
 
-      class Value < Result
+      class Rule::Result::Value < Rule::Result
         def to_ary
           [:input, [rule.name, input, [rule.to_ary]]]
         end

--- a/lib/dry/validation/schema.rb
+++ b/lib/dry/validation/schema.rb
@@ -82,12 +82,7 @@ module Dry
           errors << Error.new(result) if result.failure?
         end
 
-        Result.new(input, errors)
-      end
-
-      def messages(input)
-        result = call(input)
-        Result.new(result.params, error_compiler.(result.to_ary))
+        Result.new(input, results, errors, error_compiler)
       end
 
       def [](name)

--- a/lib/dry/validation/schema.rb
+++ b/lib/dry/validation/schema.rb
@@ -68,17 +68,12 @@ module Dry
         end
 
         groups.each do |group|
-          values = group.rules.map { |name|
-            success = result.successes.detect { |r| r.name == name }
-            success && success.input
-          }.compact
+          result.with_values(group.rules) do |values|
+            rule_result = group.(*values)
 
-          next if values.empty?
-
-          rule_result = group.(*values)
-
-          result << rule_result
-          errors << Error.new(rule_result) if rule_result.failure?
+            result << rule_result
+            errors << Error.new(rule_result) if rule_result.failure?
+          end
         end
 
         Schema::Result.new(input, result, errors, error_compiler)

--- a/lib/dry/validation/schema.rb
+++ b/lib/dry/validation/schema.rb
@@ -61,20 +61,14 @@ module Dry
 
       def call(input)
         result = Validation::Result.new(rules.map { |rule| rule.(input) })
-        errors = Error::Set.new
-
-        result.failures.each do |failure|
-          errors << Error.new(failure)
-        end
 
         groups.each do |group|
           result.with_values(group.rules) do |values|
-            rule_result = group.(*values)
-
-            result << rule_result
-            errors << Error.new(rule_result) if rule_result.failure?
+            result << group.(*values)
           end
         end
+
+        errors = Error::Set.new(result.failures.map { |failure| Error.new(failure) })
 
         Schema::Result.new(input, result, errors, error_compiler)
       end

--- a/lib/dry/validation/schema/result.rb
+++ b/lib/dry/validation/schema/result.rb
@@ -1,20 +1,26 @@
 module Dry
   module Validation
     class Schema::Result
-      include Dry::Equalizer(:params, :errors)
+      include Dry::Equalizer(:params, :messages)
       include Enumerable
 
       attr_reader :params
 
+      attr_reader :result
+
       attr_reader :errors
 
-      def initialize(params, errors)
+      attr_reader :error_compiler
+
+      def initialize(params, result, errors, error_compiler)
         @params = params
+        @result = result
         @errors = errors
+        @error_compiler = error_compiler
       end
 
       def each(&block)
-        errors.each(&block)
+        failures.each(&block)
       end
 
       def empty?
@@ -23,6 +29,18 @@ module Dry
 
       def to_ary
         errors.map(&:to_ary)
+      end
+
+      def messages
+        @messages ||= error_compiler.(errors.map(&:to_ary))
+      end
+
+      def successes
+        result.select(&:successes?)
+      end
+
+      def failures
+        result.select(&:failure?)
       end
     end
   end

--- a/lib/dry/validation/schema/result.rb
+++ b/lib/dry/validation/schema/result.rb
@@ -36,11 +36,11 @@ module Dry
       end
 
       def successes
-        result.select(&:successes?)
+        result.successes
       end
 
       def failures
-        result.select(&:failure?)
+        result.failures
       end
     end
   end

--- a/spec/integration/custom_error_messages_spec.rb
+++ b/spec/integration/custom_error_messages_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Dry::Validation, 'with custom messages' do
 
     describe '#messages' do
       it 'returns compiled error messages' do
-        expect(validation.messages(attrs.merge(email: ''))).to match_array([
+        expect(validation.(attrs.merge(email: '')).messages).to match_array([
           [:email, ["email can't be blank"]]
         ])
       end

--- a/spec/integration/schema_form_spec.rb
+++ b/spec/integration/schema_form_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe Dry::Validation::Schema::Form do
 
     describe '#messages' do
       it 'returns compiled error messages' do
-        result = validation.messages('email' => '', 'age' => '19')
+        result = validation.('email' => '', 'age' => '19')
 
-        expect(result).to match_array([
+        expect(result.messages).to match_array([
           [:email, ["email must be filled"]],
           [:address, ["address is missing"]]
         ])

--- a/spec/integration/schema_spec.rb
+++ b/spec/integration/schema_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Dry::Validation::Schema do
 
     describe '#messages' do
       it 'returns compiled error messages' do
-        expect(validation.messages(attrs.merge(email: ''))).to match_array([
+        expect(validation.(attrs.merge(email: '')).messages).to match_array([
           [:email, ["email must be filled"]]
         ])
       end


### PR DESCRIPTION
This PR breaks API but it makes it cleaner:

* `Schema` always uses injected error compiler which can do whatever
* `Schema#messages` **is gone**
* To get compiled messages you can do `Schema#call(input).messages`
* `Schema#call` returns a schema result object which has access to:
  * all validation results (can return successes and failures separately too)
  * an error set
  * compiled messages using the error compiler provided by the schema which uses the error set to produce different representation of raw errors (and it's lazy)
  * potentially coerced params
* `Validation::Result` is now an object gathering all rule results (instances of `Rule::Result`), it provides lower level APIs for working with success and failure results
* `Error::Set` is no longer mutable (yay!) and we simply pass it into `Schema::Result`

This is the first step towards having more error compilers, like I18n, raw hash etc.