### PR TITLE
Add 'pathname' require to messages abstract

### DIFF
--- a/lib/dry/validation/messages/abstract.rb
+++ b/lib/dry/validation/messages/abstract.rb
@@ -1,3 +1,4 @@
+require 'pathname'
 require 'thread_safe/cache'
 
 module Dry


### PR DESCRIPTION
Requiring 'dry-validation' without any other requires produced an error for me:

    $ irb -rdry-validation
    /Users/johnbackus/.rvm/gems/ruby-2.2.3/gems/dry-validation-0.3.0/lib/dry/validation/messages/abstract.rb:9:in `<class:Abstract>': undefined method `Pathname' for Dry::Validation::Messages::Abstract:Class (NoMethodError)