### PR TITLE
Handle invalid arguments on Schema#call

### DIFF
--- a/lib/dry/validation/schema.rb
+++ b/lib/dry/validation/schema.rb
@@ -66,6 +66,8 @@ module Dry
       end
 
       def call(input)
+        validate_input(input)
+
         result = Validation::Result.new(rules.map { |rule| rule.(input) })
 
         groups.each do |group|
@@ -91,6 +93,14 @@ module Dry
 
       def predicates
         self.class.predicates
+      end
+
+      private
+
+      def validate_input(input)
+        unless input.is_a?(Hash)
+          raise ArgumentError, "expected a Hash but received +#{input.inspect}+"
+        end
       end
     end
   end

--- a/spec/integration/schema_spec.rb
+++ b/spec/integration/schema_spec.rb
@@ -140,6 +140,10 @@ RSpec.describe Dry::Validation::Schema do
           ]]
         ])
       end
+
+      it 'raises argument error if key and valid are not provided' do
+        expect { validation.(:phone_numbers) }.to raise_error(ArgumentError, /expected a Hash/)
+      end
     end
   end
 end


### PR DESCRIPTION
Given the setup:

```ruby
class Schema < Dry::Validation::Schema
  key(:email, &:filled?)
end

schema = Schema.new
```

When calling:
```ruby
schema.call(nil)
```

You receive:
```
ArgumentError: expected a Hash but received +nil+ from /.../lib/dry/validation/schema.rb:102:in `validate_input'
```

Instead of:
```
NoMethodError: undefined method `[]' for nil:NilClass from /.../lib/dry/validation/rule/key.rb:13:in `call'
```

Obviously, this also works when passing in Strings, Arrays, or anything besides a Hash, and I believe it makes the error much clearer, and stops before it heads down into the rules.

I also see that this may conflict with #29, so I thought I could also use duck typing to determine whether or not the input is valid, but I figured I would leave that up for discussion since that pull request is not finished yet.