### PR TITLE
Nested schemas and generic rules composition

### DIFF
--- a/lib/dry/validation/error_compiler.rb
+++ b/lib/dry/validation/error_compiler.rb
@@ -31,6 +31,11 @@ module Dry
         { name => [rules.map { |rule| visit(rule, name, value) }, value] }
       end
 
+      def visit_rule(node, *args)
+        name, _ = node
+        messages[name, rule: name]
+      end
+
       def visit_key(rule, name, value)
         _, predicate = rule
         visit(predicate, value, name)

--- a/lib/dry/validation/result.rb
+++ b/lib/dry/validation/result.rb
@@ -13,6 +13,10 @@ module Dry
         rule_results.each(&block)
       end
 
+      def merge!(other)
+        rule_results.concat(other.rule_results)
+      end
+
       def to_ary
         failures.map(&:to_ary)
       end

--- a/lib/dry/validation/result.rb
+++ b/lib/dry/validation/result.rb
@@ -13,6 +13,10 @@ module Dry
         rule_results.each(&block)
       end
 
+      def to_h
+        each_with_object({}) { |result, hash| hash[result.name] = result }
+      end
+
       def merge!(other)
         rule_results.concat(other.rule_results)
       end

--- a/lib/dry/validation/rule.rb
+++ b/lib/dry/validation/rule.rb
@@ -10,6 +10,10 @@ module Dry
         @predicate = predicate
       end
 
+      def type
+        :rule
+      end
+
       def call(*args)
         Validation.Result(args, predicate.call, self)
       end

--- a/lib/dry/validation/rule.rb
+++ b/lib/dry/validation/rule.rb
@@ -10,6 +10,10 @@ module Dry
         @predicate = predicate
       end
 
+      def call(*args)
+        Validation.Result(args, predicate.call, self)
+      end
+
       def to_ary
         [type, [name, predicate.to_ary]]
       end

--- a/lib/dry/validation/rule/composite.rb
+++ b/lib/dry/validation/rule/composite.rb
@@ -6,9 +6,12 @@ module Dry
       attr_reader :name, :left, :right
 
       def initialize(left, right)
-        @name = left.name
         @left = left
         @right = right
+      end
+
+      def name
+        :"#{left.name}_#{type}_#{right.name}"
       end
 
       def to_ary
@@ -18,8 +21,8 @@ module Dry
     end
 
     class Rule::Implication < Rule::Composite
-      def call(input)
-        left.(input) > right
+      def call(*args)
+        left.(*args) > right
       end
 
       def type
@@ -28,8 +31,8 @@ module Dry
     end
 
     class Rule::Conjunction < Rule::Composite
-      def call(input)
-        left.(input).and(right)
+      def call(*args)
+        left.(*args).and(right)
       end
 
       def type
@@ -38,8 +41,8 @@ module Dry
     end
 
     class Rule::Disjunction < Rule::Composite
-      def call(input)
-        left.(input).or(right)
+      def call(*args)
+        left.(*args).or(right)
       end
 
       def type

--- a/lib/dry/validation/rule/result.rb
+++ b/lib/dry/validation/rule/result.rb
@@ -2,6 +2,7 @@ module Dry
   module Validation
     def self.Result(input, value, rule)
       case value
+      when Rule::Result then value.class.new(value.input, value.success?, rule)
       when Array then Rule::Result::Set.new(input, value, rule)
       else Rule::Result::Value.new(input, value, rule)
       end
@@ -35,6 +36,14 @@ module Dry
         @value = value
         @rule = rule
         @name = rule.name
+      end
+
+      def call
+        self
+      end
+
+      def curry(*args)
+        self
       end
 
       def >(other)

--- a/lib/dry/validation/rule_compiler.rb
+++ b/lib/dry/validation/rule_compiler.rb
@@ -18,6 +18,11 @@ module Dry
         send(:"visit_#{name}", nodes)
       end
 
+      def visit_rule(node)
+        name, predicate = node
+        Rule.new(name, visit(predicate))
+      end
+
       def visit_key(node)
         name, predicate = node
         Rule::Key.new(name, visit(predicate))

--- a/lib/dry/validation/schema.rb
+++ b/lib/dry/validation/schema.rb
@@ -59,6 +59,10 @@ module Dry
         @__groups__ ||= []
       end
 
+      def self.generics
+        @__generics__ ||= []
+      end
+
       attr_reader :rules, :groups
 
       attr_reader :error_compiler

--- a/lib/dry/validation/schema.rb
+++ b/lib/dry/validation/schema.rb
@@ -67,7 +67,7 @@ module Dry
         @__generics__ ||= []
       end
 
-      attr_reader :rules, :schemas, :groups
+      attr_reader :rules, :schemas, :groups, :generics
 
       attr_reader :error_compiler
 
@@ -76,8 +76,9 @@ module Dry
       def initialize(error_compiler = self.class.error_compiler, hint_compiler = self.class.hint_compiler)
         compiler = RuleCompiler.new(self)
         @rules = compiler.(self.class.rules.map(&:to_ary))
-        @schemas = self.class.schemas.map(&:new)
+        @generics = self.class.generics
         @groups = compiler.(self.class.groups.map(&:to_ary))
+        @schemas = self.class.schemas.map(&:new)
         @error_compiler = error_compiler
         @hint_compiler = hint_compiler
       end
@@ -87,6 +88,14 @@ module Dry
 
         schemas.each do |schema|
           result.merge!(schema.(input).result)
+        end
+
+        if generics.size > 0
+          compiled_generics = RuleCompiler.new(result.to_h).(generics)
+
+          compiled_generics.each do |rule|
+            result << rule.()
+          end
         end
 
         groups.each do |group|

--- a/lib/dry/validation/schema/definition.rb
+++ b/lib/dry/validation/schema/definition.rb
@@ -2,6 +2,13 @@ module Dry
   module Validation
     class Schema
       module Definition
+        def schema(name, &block)
+          schema = Class.new(superclass)
+          schema.key(name, &block)
+          schemas << schema
+          self
+        end
+
         def key(name, &block)
           Key.new(name, rules).key?(&block)
         end

--- a/lib/dry/validation/schema/definition.rb
+++ b/lib/dry/validation/schema/definition.rb
@@ -18,16 +18,17 @@ module Dry
         end
 
         def rule(name, **options, &block)
-          if block
-            gen_name, rule_names = name.to_a.first
-            gen_rule = yield(*rule_names.map { |rule| rule_by_name(rule).to_generic })
-
-            generics << Schema::Rule.new(gen_name, [:rule, [gen_name, gen_rule.to_ary]])
-          else
+          if options.any?
             predicate, rule_names = options.to_a.first
             identifier = { name => rule_names }
 
             groups << [:group, [identifier, [:predicate, predicate]]]
+          else
+            if block
+              generics << Schema::Rule.new(name, [:rule, [name, yield.to_ary]])
+            else
+              rule_by_name(name).to_generic
+            end
           end
         end
 

--- a/lib/dry/validation/schema/key.rb
+++ b/lib/dry/validation/schema/key.rb
@@ -18,9 +18,9 @@ module Dry
 
           rules <<
             if val_rule.is_a?(::Array)
-              Schema::Rule.new([:implication, [key_rule.to_ary, [:set, [name, val_rule.map(&:to_ary)]]]])
+              Schema::Rule.new(name, [:implication, [key_rule.to_ary, [:set, [name, val_rule.map(&:to_ary)]]]])
             else
-              Schema::Rule.new([:implication, [key_rule.to_ary, val_rule.to_ary]])
+              Schema::Rule.new(name, [:implication, [key_rule.to_ary, val_rule.to_ary]])
             end
         end
 
@@ -34,12 +34,12 @@ module Dry
 
             rules <<
               if val_rule.is_a?(::Array)
-                Schema::Rule.new([:and, [key_rule, [:set, [name, val_rule.map(&:to_ary)]]]])
+                Schema::Rule.new(name, [:and, [key_rule, [:set, [name, val_rule.map(&:to_ary)]]]])
               else
-                Schema::Rule.new([:and, [key_rule, val_rule.to_ary]])
+                Schema::Rule.new(name, [:and, [key_rule, val_rule.to_ary]])
               end
           else
-            Schema::Rule.new(key_rule)
+            Schema::Rule.new(name, key_rule)
           end
         end
 

--- a/lib/dry/validation/schema/rule.rb
+++ b/lib/dry/validation/schema/rule.rb
@@ -4,7 +4,11 @@ module Dry
       class Rule
         attr_reader :name, :node
 
-        def initialize(node)
+        class Generic < Rule
+        end
+
+        def initialize(name, node)
+          @name = name
           @node = node
         end
 
@@ -13,18 +17,22 @@ module Dry
         end
         alias_method :to_a, :to_ary
 
+        def to_generic
+          Rule::Generic.new(name, [:rule, [name, [:predicate, [name, []]]]])
+        end
+
         def and(other)
-          self.class.new([:and, [node, other.to_ary]])
+          self.class.new(name, [:and, [node, other.to_ary]])
         end
         alias_method :&, :and
 
         def or(other)
-          self.class.new([:or, [node, other.to_ary]])
+          self.class.new(name, [:or, [node, other.to_ary]])
         end
         alias_method :|, :or
 
         def then(other)
-          self.class.new([:implication, [node, other.to_ary]])
+          self.class.new(name, [:implication, [node, other.to_ary]])
         end
         alias_method :>, :then
       end

--- a/lib/dry/validation/schema/rule.rb
+++ b/lib/dry/validation/schema/rule.rb
@@ -22,17 +22,17 @@ module Dry
         end
 
         def and(other)
-          self.class.new(name, [:and, [node, other.to_ary]])
+          self.class.new(:"#{name}_and_#{other.name}", [:and, [node, other.to_ary]])
         end
         alias_method :&, :and
 
         def or(other)
-          self.class.new(name, [:or, [node, other.to_ary]])
+          self.class.new(:"#{name}_or_#{other.name}", [:or, [node, other.to_ary]])
         end
         alias_method :|, :or
 
         def then(other)
-          self.class.new(name, [:implication, [node, other.to_ary]])
+          self.class.new(:"#{name}_then_#{other.name}", [:implication, [node, other.to_ary]])
         end
         alias_method :>, :then
       end

--- a/lib/dry/validation/schema/value.rb
+++ b/lib/dry/validation/schema/value.rb
@@ -4,12 +4,13 @@ module Dry
       class Value < BasicObject
         include Schema::Definition
 
-        attr_reader :name, :rules, :groups
+        attr_reader :name, :rules, :groups, :generics
 
         def initialize(name)
           @name = name
           @rules = []
           @groups = []
+          @generics = []
         end
 
         def each(&block)
@@ -22,13 +23,13 @@ module Dry
               [:set, [name, rules.map(&:to_ary)]]
             end
 
-          Schema::Rule.new([:each, [name, each_rule]])
+          Schema::Rule.new(name, [:each, [name, each_rule]])
         end
 
         private
 
         def method_missing(meth, *args, &block)
-          rule = Schema::Rule.new([:val, [name, [:predicate, [meth, args]]]])
+          rule = Schema::Rule.new(name, [:val, [name, [:predicate, [meth, args]]]])
 
           if block
             val_rule = yield
@@ -36,7 +37,7 @@ module Dry
             if val_rule.is_a?(Schema::Rule)
               rule & val_rule
             else
-              Schema::Rule.new([:and, [rule.to_ary, [:set, [name, rules.map(&:to_ary)]]]])
+              Schema::Rule.new(name, [:and, [rule.to_ary, [:set, [name, rules.map(&:to_ary)]]]])
             end
           else
             rule

--- a/spec/integration/schema/generic_rules_spec.rb
+++ b/spec/integration/schema/generic_rules_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Schema, 'using generic rules' do
       optional(:red, &:filled?)
       optional(:blue, &:filled?)
 
-      rule(destiny: [:red, :blue]) { |red, blue| red | blue }
+      rule(:destiny) { rule(:red) | rule(:blue) }
     end
   end
 

--- a/spec/integration/schema/generic_rules_spec.rb
+++ b/spec/integration/schema/generic_rules_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe Schema, 'using generic rules' do
+  subject(:validate) { schema.new }
+
+  let(:schema) do
+    Class.new(Schema) do
+      def self.messages
+        Messages.default.merge(
+          en: { errors: { destiny: 'you must select either red or blue' } }
+        )
+      end
+
+      optional(:red, &:filled?)
+      optional(:blue, &:filled?)
+
+      rule(destiny: [:red, :blue]) { |red, blue| red | blue }
+    end
+  end
+
+  it 'passes when only red is filled' do
+    expect(validate.(red: '1')).to be_empty
+  end
+
+  it 'fails when red and blue are not filled ' do
+    expect(validate.(red: '', blue: '').messages[:destiny]).to eql(
+      [['you must select either red or blue'], '']
+    )
+  end
+end

--- a/spec/integration/schema/nested_spec.rb
+++ b/spec/integration/schema/nested_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe Schema, 'using nested schemas' do
+  subject(:validate) { schema.new }
+
+  let(:schema) do
+    Class.new(Schema) do
+      schema(:location) do |loc|
+        loc.key(:lat, &:filled?)
+        loc.key(:lng, &:filled?)
+      end
+    end
+  end
+
+  it 'passes when location has lat and lng filled' do
+    expect(validate.(location: { lat: 1.23, lng: 4.56 })).to be_empty
+  end
+
+  it 'fails when location has missing lat' do
+    expect(validate.(location: { lng: 4.56 })).to match_array([
+      [
+        :error, [
+          :input, [
+            :location, { lng: 4.56 },
+            [
+              [:input, [:lat, nil, [[:key, [:lat, [:predicate, [:key?, [:lat]]]]]]]]
+            ]
+          ]
+        ]
+      ]
+    ])
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
 # encoding: utf-8
 
-require 'dry-validation'
-
 begin
   require 'byebug'
 rescue LoadError; end
+
+require 'dry-validation'
 
 SPEC_ROOT = Pathname(__dir__)
 

--- a/spec/unit/rule_compiler_spec.rb
+++ b/spec/unit/rule_compiler_spec.rb
@@ -9,12 +9,21 @@ RSpec.describe Dry::Validation::RuleCompiler, '#call' do
 
   let(:predicate) { double(:predicate).as_null_object }
 
+  let(:generic_rule) { Rule.new(:generic, predicate) }
   let(:key_rule) { Rule::Key.new(:email, predicate) }
   let(:val_rule) { Rule::Value.new(:email, predicate) }
   let(:and_rule) { key_rule & val_rule }
   let(:or_rule) { key_rule | val_rule }
   let(:set_rule) { Rule::Set.new(:email, [val_rule]) }
   let(:each_rule) { Rule::Each.new(:email, val_rule) }
+
+  it 'compiles generic rule' do
+    ast = [[:rule, [:generic, [:predicate, [:key?, []]]]]]
+
+    rules = compiler.(ast)
+
+    expect(rules).to eql([generic_rule])
+  end
 
   it 'compiles key rules' do
     ast = [[:key, [:email, [:predicate, [:key?, predicate]]]]]
@@ -28,8 +37,8 @@ RSpec.describe Dry::Validation::RuleCompiler, '#call' do
     ast = [
       [
         :and, [
-          [:key, [:email, [:predicate, [:key?, predicate]]]],
-          [:val, [:email, [:predicate, [:filled?, predicate]]]]
+          [:key, [:email, [:predicate, [:key?, []]]]],
+          [:val, [:email, [:predicate, [:filled?, []]]]]
         ]
       ]
     ]
@@ -43,8 +52,8 @@ RSpec.describe Dry::Validation::RuleCompiler, '#call' do
     ast = [
       [
         :or, [
-          [:key, [:email, [:predicate, [:key?, predicate]]]],
-          [:val, [:email, [:predicate, [:filled?, predicate]]]]
+          [:key, [:email, [:predicate, [:key?, []]]]],
+          [:val, [:email, [:predicate, [:filled?, []]]]]
         ]
       ]
     ]
@@ -59,7 +68,7 @@ RSpec.describe Dry::Validation::RuleCompiler, '#call' do
       [
         :set, [
           :email, [
-            [:val, [:email, [:predicate, [:filled?, predicate]]]]
+            [:val, [:email, [:predicate, [:filled?, []]]]]
           ]
         ]
       ]
@@ -74,7 +83,7 @@ RSpec.describe Dry::Validation::RuleCompiler, '#call' do
     ast = [
       [
         :each, [
-          :email, [:val, [:email, [:predicate, [:filled?, predicate]]]]
+          :email, [:val, [:email, [:predicate, [:filled?, []]]]]
         ]
       ]
     ]

--- a/spec/unit/rule_spec.rb
+++ b/spec/unit/rule_spec.rb
@@ -15,19 +15,19 @@ RSpec.describe Rule do
 
     describe '#and' do
       it 'returns a conjunction' do
-        expect(left.and(right).call('input')).to be_failure
+        expect(left.and(right).call).to be_failure
       end
     end
 
     describe '#or' do
       it 'returns a conjunction' do
-        expect(left.or(right).call('input')).to be_success
+        expect(left.or(right).call).to be_success
       end
     end
 
     describe '#then' do
       it 'returns an implication' do
-        expect(left.then(right).call('input')).to be_failure
+        expect(left.then(right).call).to be_failure
       end
     end
   end

--- a/spec/unit/rule_spec.rb
+++ b/spec/unit/rule_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe Rule do
+  describe '#call' do
+    subject(:rule) { Rule.new(:name, predicate) }
+
+    let(:predicate) { -> { true } }
+
+    it 'returns result of its predicate' do
+      expect(rule.call).to be_success
+    end
+  end
+
+  describe 'composition' do
+    let(:left) { Rule.new(:left, -> { true }) }
+    let(:right) { Rule.new(:left, -> { false }) }
+
+    describe '#and' do
+      it 'returns a conjunction' do
+        expect(left.and(right).call('input')).to be_failure
+      end
+    end
+
+    describe '#or' do
+      it 'returns a conjunction' do
+        expect(left.or(right).call('input')).to be_success
+      end
+    end
+
+    describe '#then' do
+      it 'returns an implication' do
+        expect(left.then(right).call('input')).to be_failure
+      end
+    end
+  end
+end

--- a/spec/unit/schema/rule_spec.rb
+++ b/spec/unit/schema/rule_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe Schema::Rule do
   let(:filled) { [:val, [:email, [:predicate, [:filled?, []]]]] }
   let(:format) { [:val, [:email, [:predicate, [:format?, [/regex/]]]]] }
 
-  let(:left) { Schema::Rule.new(filled) }
-  let(:right) { Schema::Rule.new(format) }
+  let(:left) { Schema::Rule.new(:email, filled) }
+  let(:right) { Schema::Rule.new(:email, format) }
 
   describe '#and' do
     it 'returns a conjunction' do

--- a/spec/unit/schema/value_spec.rb
+++ b/spec/unit/schema/value_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Schema::Value do
       pills.key(:red, &:filled?)
       pills.key(:blue, &:filled?)
 
-      pills.rule(destiny: [:red, :blue]) { |red, blue| red | blue }
+      pills.rule(:destiny) { pills.rule(:red) | pills.rule(:blue) }
 
       expect(pills.generics.map(&:to_ary)).to match_array([
         [

--- a/spec/unit/schema/value_spec.rb
+++ b/spec/unit/schema/value_spec.rb
@@ -40,4 +40,28 @@ RSpec.describe Schema::Value do
       )
     end
   end
+
+  describe '#rule' do
+    subject(:pills) { Schema::Value.new(:pills) }
+
+    it 'appends new group rule' do
+      pills.key(:red, &:filled?)
+      pills.key(:blue, &:filled?)
+
+      pills.rule(destiny: [:red, :blue]) { |red, blue| red | blue }
+
+      expect(pills.generics.map(&:to_ary)).to match_array([
+        [
+          :rule, [
+            :destiny, [
+              :or, [
+                [:rule, [:red, [:predicate, [:red, []]]]],
+                [:rule, [:blue, [:predicate, [:blue, []]]]]
+              ]
+            ]
+          ]
+        ]
+      ])
+    end
+  end
 end


### PR DESCRIPTION
This adds two big features:

* Ability to define schemas within a schema for complex logic and to be able to re-use schema easily
* Ability to compose generic rules via `rule` syntax and common logic operators

### Nested Schema

``` ruby
class CitySchema < Dry::Validation::Schema
  key(:name, &:filled?)

  schema(:location) do |loc|
    loc.key(:lat)
    loc.key(:lng)
  end
end
```

This is a trivial example just to show the syntax, the reason for using `schema` rather than just `key` is when you want to use higher-level concepts like `rule` interface. I'll add a feature where a schema class can be passed too, so that you can share schemas across other schemas (such schemas!) easily and avoid duplication.

### Generic Rule Composition

Not sure if generic is a good name (feedback welcome!) but the idea is that after rules have been applied you can take results to build up a higher-level rules without the need to apply their predicates again.

``` ruby
class NeoSchema < Dry::Validation::Schema
  schema(:pills) do
    optional(:red, &:filled?)
    optional(:blue, &:filled?)

    rule(:destiny) { rule(:red) | rule(:blue) }
  end
end
```

This translates to "pills must be present and either :red is filled or :blue".

refs #25 